### PR TITLE
Python Requirements File

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp
+xmltodict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp
-xmltodict
+aiohttp==3.8.1
+xmltodict==0.13.0


### PR DESCRIPTION
To fix errors:
ModuleNotFoundError: No module named 'aiohttp'
ModuleNotFoundError: No module named 'xmltodict'